### PR TITLE
off by one indices

### DIFF
--- a/lib_prompt_fusion/dsl_prompt_transpiler.py
+++ b/lib_prompt_fusion/dsl_prompt_transpiler.py
@@ -101,7 +101,7 @@ class ExpressionLarkTransformer(Transformer):
 
         steps = [None if not step
                  else ast.SubstitutionExpression(step[1:]) if step.startswith('$')
-                 else ast.LiftExpression(step)
+                 else ast.LiftExpression(float(step) + 1)
                  for step in str(subexprs[-1]).split(',')]
         subexprs = subexprs[:-1]
         if len(steps) > 1:


### PR DESCRIPTION
I incorrectly made interpolation indices 0-based when fixing the interpolation parsing. Now they're -1 based as they should to be consistent with prompt editing from webui.