### PR TITLE
average V1

### DIFF
--- a/lib_prompt_fusion/prompt_parser.py
+++ b/lib_prompt_fusion/prompt_parser.py
@@ -125,12 +125,7 @@ def parse_interpolation(prompt, stoppers):
     prompt, steps = parse_interpolation_steps(prompt, stoppers)
     prompt, function_name = parse_interpolation_function_name(prompt, stoppers)
     prompt, _ = parse_close_square(prompt, stoppers)
-
-    max_len = min(len(exprs), len(steps))
-    exprs = exprs[:max_len]
-    steps = steps[:max_len]
-
-    return ParseResult(prompt=prompt, expr=ast.InterpolationExpression(exprs, steps, function_name))
+    return ParseResult(prompt=prompt, expr=ast.InterpolationExpression.create(exprs, steps, function_name))
 
 
 def parse_interpolation_exprs(prompt, stoppers):
@@ -153,7 +148,7 @@ def parse_interpolation_exprs(prompt, stoppers):
 def parse_interpolation_function_name(prompt, stoppers):
     try:
         prompt, _ = parse_colon(prompt, stoppers)
-        function_names = ('linear', 'catmull', 'bezier')
+        function_names = ('linear', 'catmull', 'bezier', 'mean')
         return parse_token(prompt, whitespace_tail_regex('|'.join(function_names), stoppers))
     except ValueError:
         return ParseResult(prompt=prompt, expr=None)

--- a/test/parser_tests.py
+++ b/test/parser_tests.py
@@ -97,7 +97,6 @@ functional_parse_test_cases = [
     ('[a:b:c::mean]', {'a', 'b', 'c'}),
     ('[a:b:c:,,:mean]', {'a', 'b', 'c'}),
     ('[a:b:c: 1, 2, 3:mean]', {'a', 'b', 'c'}),
-    ('[a:b:c: 1, 2, 3:mean]', {'a', 'b', 'c'}),
 ]
 
 

--- a/test/parser_tests.py
+++ b/test/parser_tests.py
@@ -6,7 +6,7 @@ def run_functional_tests(total_steps=100):
     for i, (given, expected) in enumerate(functional_parse_test_cases):
         expr = parse_prompt(given)
         tensor_builder = InterpolationTensorBuilder()
-        expr.extend_tensor(tensor_builder, (0, total_steps), total_steps, dict())
+        expr.extend_tensor(tensor_builder, (0, total_steps), total_steps, dict(), is_hires=False, use_old_scheduling=False)
 
         actual = tensor_builder.get_prompt_database()
 
@@ -94,6 +94,10 @@ functional_parse_test_cases = [
     ('[a|b|c:0.5]', {'a', 'b', 'c'}),
     ('[a|b|c:1.1]', {'a', 'b', 'c'}),
     ('[[[Imperial Yellow|Amber]:[Ruby|Plum|Bronze]:9]::39]',)*2,
+    ('[a:b:c::mean]', {'a', 'b', 'c'}),
+    ('[a:b:c:,,:mean]', {'a', 'b', 'c'}),
+    ('[a:b:c: 1, 2, 3:mean]', {'a', 'b', 'c'}),
+    ('[a:b:c: 1, 2, 3:mean]', {'a', 'b', 'c'}),
 ]
 
 


### PR DESCRIPTION
Adds syntax support for static weighted average of conditions:

```
[a : b : c : 1, 1 : mean]
```

This will merge `a` * 0.5 and `b` * 0.5 for the entire schedule. The schedule is always normalized to sum up to 1. For example, this is equivalent to the above:

```
[a : b : c : 10, 10 : mean]
```

This will merge `a` * 0.3333... and `b` * 0.6666... for the entire schedule:

```
[a : b : c : 5, 10 : mean]
```

It is possible to omit weights, they default to the inverse of the number of subprompts. For example:

```
[a : b : c : d : e : , , , , : mean]
```

will give a weight of 1/5 to each of `a`, `b`, `c`, etc. This is equivalent but shorter:

```
[a : b : c : d : e :: mean]
```

related: #75 